### PR TITLE
Fix parsing error on token param

### DIFF
--- a/lib/repositories/__tests__/customer-test.js
+++ b/lib/repositories/__tests__/customer-test.js
@@ -807,7 +807,7 @@ describe('Repository', () => {
       };
       getRequestBuilder = repository.getRequestBuilder;
       getRequestBuilderMocked = jest.fn(() => ({
-        customers: mockedService
+        customersPasswordToken: mockedService
       }));
       repository.getRequestBuilder = getRequestBuilderMocked;
       body = {
@@ -830,7 +830,10 @@ describe('Repository', () => {
 
     it('should call connection.execute with params', () => {
       expect(repository.connection.execute).toHaveBeenCalledWith({
-        uri: repository.getRequestBuilder().customers.parse({}).build(),
+        uri: repository
+          .getRequestBuilder()
+          .customersPasswordToken.parse({})
+          .build(),
         method: 'POST',
         body: JSON.stringify(body)
       });
@@ -840,18 +843,22 @@ describe('Repository', () => {
       expect(repository.getRequestBuilder).toHaveBeenCalled();
     });
 
-    it('should call getRequestBuilder().customers.parse', () => {
-      expect(repository.getRequestBuilder().customers.parse).toHaveBeenCalled();
+    it('should call getRequestBuilder().customersPasswordToken.parse', () => {
+      expect(
+        repository.getRequestBuilder().customersPasswordToken.parse
+      ).toHaveBeenCalled();
     });
 
-    it('should call getRequestBuilder().customers.parse with params', () => {
+    it('should call getRequestBuilder().customersPasswordToken.parse with params', () => {
       expect(
-        repository.getRequestBuilder().customers.parse
+        repository.getRequestBuilder().customersPasswordToken.parse
       ).toHaveBeenCalledWith(queryParams);
     });
 
-    it('should call getRequestBuilder().customers.build', () => {
-      expect(repository.getRequestBuilder().customers.build).toHaveBeenCalled();
+    it('should call getRequestBuilder().customersPasswordToken.build', () => {
+      expect(
+        repository.getRequestBuilder().customersPasswordToken.build
+      ).toHaveBeenCalled();
     });
 
     it('should return response.body', () => {
@@ -1079,7 +1086,7 @@ describe('Repository', () => {
     let getRequestBuilderMocked;
     let mockedService;
     let token = 't3stT0k3n';
-    const queryParams = { token };
+    const queryParams = { id: `email-token=${token}` };
     let res;
 
     beforeAll(() => {
@@ -1089,7 +1096,7 @@ describe('Repository', () => {
       };
       getRequestBuilder = repository.getRequestBuilder;
       getRequestBuilderMocked = jest.fn(() => ({
-        customersEmailVerificationToken: mockedService
+        customers: mockedService
       }));
       repository.getRequestBuilder = getRequestBuilderMocked;
     });
@@ -1110,7 +1117,7 @@ describe('Repository', () => {
       expect(repository.connection.execute).toHaveBeenCalledWith({
         uri: repository
           .getRequestBuilder()
-          .customersEmailVerificationToken.parse(queryParams)
+          .customers.parse(queryParams)
           .build(),
         method: 'GET'
       });
@@ -1120,22 +1127,18 @@ describe('Repository', () => {
       expect(repository.getRequestBuilder).toHaveBeenCalled();
     });
 
-    it('should call getRequestBuilder().customersEmailVerificationToken.parse', () => {
-      expect(
-        repository.getRequestBuilder().customersEmailVerificationToken.parse
-      ).toHaveBeenCalled();
+    it('should call getRequestBuilder().customers.parse', () => {
+      expect(repository.getRequestBuilder().customers.parse).toHaveBeenCalled();
     });
 
-    it('should call getRequestBuilder().customersEmailVerificationToken.parse with params', () => {
+    it('should call getRequestBuilder().customers.parse with params', () => {
       expect(
-        repository.getRequestBuilder().customersEmailVerificationToken.parse
+        repository.getRequestBuilder().customers.parse
       ).toHaveBeenCalledWith(queryParams);
     });
 
-    it('should call getRequestBuilder().customersEmailVerificationToken.build', () => {
-      expect(
-        repository.getRequestBuilder().customersEmailVerificationToken.build
-      ).toHaveBeenCalled();
+    it('should call getRequestBuilder().customers.build', () => {
+      expect(repository.getRequestBuilder().customers.build).toHaveBeenCalled();
     });
 
     it('should return response.body', () => {

--- a/lib/repositories/__tests__/customer-test.js
+++ b/lib/repositories/__tests__/customer-test.js
@@ -807,7 +807,7 @@ describe('Repository', () => {
       };
       getRequestBuilder = repository.getRequestBuilder;
       getRequestBuilderMocked = jest.fn(() => ({
-        customersPasswordToken: mockedService
+        customers: mockedService
       }));
       repository.getRequestBuilder = getRequestBuilderMocked;
       body = {
@@ -830,10 +830,7 @@ describe('Repository', () => {
 
     it('should call connection.execute with params', () => {
       expect(repository.connection.execute).toHaveBeenCalledWith({
-        uri: repository
-          .getRequestBuilder()
-          .customersPasswordToken.parse({})
-          .build(),
+        uri: repository.getRequestBuilder().customers.parse({}).build(),
         method: 'POST',
         body: JSON.stringify(body)
       });
@@ -843,22 +840,18 @@ describe('Repository', () => {
       expect(repository.getRequestBuilder).toHaveBeenCalled();
     });
 
-    it('should call getRequestBuilder().customersPasswordToken.parse', () => {
-      expect(
-        repository.getRequestBuilder().customersPasswordToken.parse
-      ).toHaveBeenCalled();
+    it('should call getRequestBuilder().customers.parse', () => {
+      expect(repository.getRequestBuilder().customers.parse).toHaveBeenCalled();
     });
 
-    it('should call getRequestBuilder().customersPasswordToken.parse with params', () => {
+    it('should call getRequestBuilder().customers.parse with params', () => {
       expect(
-        repository.getRequestBuilder().customersPasswordToken.parse
+        repository.getRequestBuilder().customers.parse
       ).toHaveBeenCalledWith(queryParams);
     });
 
-    it('should call getRequestBuilder().customersPasswordToken.build', () => {
-      expect(
-        repository.getRequestBuilder().customersPasswordToken.build
-      ).toHaveBeenCalled();
+    it('should call getRequestBuilder().customers.build', () => {
+      expect(repository.getRequestBuilder().customers.build).toHaveBeenCalled();
     });
 
     it('should return response.body', () => {
@@ -871,7 +864,7 @@ describe('Repository', () => {
     let getRequestBuilderMocked;
     let mockedService;
     let token = 't3stT0k3n';
-    const queryParams = { token };
+    const queryParams = { id: `password-token=${token}` };
     let res;
 
     beforeAll(() => {
@@ -881,7 +874,7 @@ describe('Repository', () => {
       };
       getRequestBuilder = repository.getRequestBuilder;
       getRequestBuilderMocked = jest.fn(() => ({
-        customersPasswordToken: mockedService
+        customers: mockedService
       }));
       repository.getRequestBuilder = getRequestBuilderMocked;
     });
@@ -902,7 +895,7 @@ describe('Repository', () => {
       expect(repository.connection.execute).toHaveBeenCalledWith({
         uri: repository
           .getRequestBuilder()
-          .customersPasswordToken.parse(queryParams)
+          .customers.parse(queryParams)
           .build(),
         method: 'GET'
       });
@@ -912,22 +905,18 @@ describe('Repository', () => {
       expect(repository.getRequestBuilder).toHaveBeenCalled();
     });
 
-    it('should call getRequestBuilder().customersPasswordToken.parse', () => {
-      expect(
-        repository.getRequestBuilder().customersPasswordToken.parse
-      ).toHaveBeenCalled();
+    it('should call getRequestBuilder().customers.parse', () => {
+      expect(repository.getRequestBuilder().customers.parse).toHaveBeenCalled();
     });
 
-    it('should call getRequestBuilder().customersPasswordToken.parse with params', () => {
+    it('should call getRequestBuilder().customers.parse with params', () => {
       expect(
-        repository.getRequestBuilder().customersPasswordToken.parse
+        repository.getRequestBuilder().customers.parse
       ).toHaveBeenCalledWith(queryParams);
     });
 
-    it('should call getRequestBuilder().customersPasswordToken.build', () => {
-      expect(
-        repository.getRequestBuilder().customersPasswordToken.build
-      ).toHaveBeenCalled();
+    it('should call getRequestBuilder().customers.build', () => {
+      expect(repository.getRequestBuilder().customers.build).toHaveBeenCalled();
     });
 
     it('should return response.body', () => {

--- a/lib/repositories/customer.js
+++ b/lib/repositories/customer.js
@@ -83,7 +83,7 @@ class Customer extends BaseRepository {
   async passwordToken(body) {
     const { email, ttlMinutes } = body;
     const response = await this.connection.execute({
-      uri: this.getRequestBuilder().customersPasswordToken.parse({}).build(),
+      uri: this.getRequestBuilder().customers.parse({}).build(),
       method: 'POST',
       body: JSON.stringify({ email, ttlMinutes })
     });
@@ -100,7 +100,7 @@ class Customer extends BaseRepository {
   async getByPasswordToken(token) {
     const response = await this.connection.execute({
       uri: this.getRequestBuilder()
-        .customersPasswordToken.parse({ token })
+        .customers.parse({ id: `password-token=${token}` })
         .build(),
       method: 'GET'
     });

--- a/lib/repositories/customer.js
+++ b/lib/repositories/customer.js
@@ -83,7 +83,7 @@ class Customer extends BaseRepository {
   async passwordToken(body) {
     const { email, ttlMinutes } = body;
     const response = await this.connection.execute({
-      uri: this.getRequestBuilder().customers.parse({}).build(),
+      uri: this.getRequestBuilder().customersPasswordToken.parse({}).build(),
       method: 'POST',
       body: JSON.stringify({ email, ttlMinutes })
     });
@@ -159,7 +159,7 @@ class Customer extends BaseRepository {
   async getByEmailToken(token) {
     const response = await this.connection.execute({
       uri: this.getRequestBuilder()
-        .customersEmailVerificationToken.parse({ token })
+        .customers.parse({ id: `email-token=${token}` })
         .build(),
       method: 'GET'
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-commercetools",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6469,9 +6469,9 @@
       "dev": true
     },
     "y18n": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
-      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
+      "integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
       "dev": true
     },
     "yargs": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fastify-commercetools",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Fastify commercetools plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
{token} does not exist as a valid parse param.

These are the valid params in the current ct impl.

https://github.com/commercetools/nodejs/blob/4974bb700aa9469282f38da4e40ecbb8bba7d513/packages/api-request-builder/src/default-params.js#L101

Since we needed the urls on this format:
customers/password-token=c8TztFfFAZj-_fduYWmNXKDhH0WE4H34l70XnZ9G

I needed to change the endpoint to customers.