### PR TITLE
Add external headers to the base repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,8 @@ fastify.register(require("fastify-commercetools"), {
     projectKey: "projectKey",
     clientId: "clientId",
     clientSecret: "clientSecret",
-    concurrency: 5
+    concurrency: 5,
+    allowedHeaders: []
   }
 });
 ```

--- a/commercetools.js
+++ b/commercetools.js
@@ -11,7 +11,8 @@ module.exports = function (fastify, opts, next) {
     clientId,
     clientSecret,
     concurrency,
-    loggingConfig = {}
+    loggingConfig = {},
+    allowedHeaders = []
   } = opts;
 
   const {
@@ -44,7 +45,8 @@ module.exports = function (fastify, opts, next) {
         body,
         error,
         logger: fastify.log
-      }
+      },
+      allowedHeaders
     },
     concurrency: concurrency || 10
   };

--- a/lib/commercetools/connection.js
+++ b/lib/commercetools/connection.js
@@ -13,6 +13,8 @@ const {
   createLoggerMiddleware
 } = require('@commercetools/sdk-middleware-logger');
 
+const ALLOWED_EXTERNAL_HEADERS = ['x-external-user-id'];
+
 function createCustomLoggerMiddleware(loggingConfig) {
   const log = loggingConfig.logger || console;
 
@@ -57,7 +59,7 @@ class Connection {
    */
   constructor(config) {
     const { commercetools, concurrency } = config;
-    const { auth, middleware, loggingConfig } = commercetools;
+    const { auth, middleware, loggingConfig, allowedHeaders } = commercetools;
     this.projectKey = auth.projectKey;
 
     let middlewares = [
@@ -82,6 +84,25 @@ class Connection {
     this.client = createClient({
       middlewares
     });
+
+    this.allowedExternalHeaders = [
+      ...ALLOWED_EXTERNAL_HEADERS,
+      ...allowedHeaders
+    ];
+  }
+
+  sanitazeHeaders(headers) {
+    if (!headers) {
+      return undefined;
+    }
+
+    const sanitazedHeaders = Object.keys(headers)
+      .filter(header =>
+        this.allowedExternalHeaders.includes(header.toLocaleLowerCase())
+      )
+      .map(header => [header, headers[header]]);
+
+    return Object.fromEntries(sanitazedHeaders);
   }
 
   /**
@@ -96,7 +117,10 @@ class Connection {
    */
   async execute(request) {
     try {
-      return await this.client.execute(request);
+      return await this.client.execute({
+        ...request,
+        headers: this.sanitazeHeaders(request.headers)
+      });
     } catch (err) {
       if (typeof err === 'object') {
         // eslint-disable-next-line

--- a/lib/repositories/__tests__/base-test.js
+++ b/lib/repositories/__tests__/base-test.js
@@ -78,27 +78,6 @@ describe('Repository', () => {
     });
   });
 
-  describe('sanitazeHeaders', () => {
-    describe('when headers are undefined', () => {
-      test('should return undefined', () => {
-        expect(repository.sanitazeHeaders()).toBeUndefined();
-      });
-    });
-
-    describe('when headers are not undefined', () => {
-      test('should return the allowed headers', () => {
-        expect(
-          repository.sanitazeHeaders({
-            'X-External-User-ID': 'user1',
-            'not-allowed-header': 'value-1'
-          })
-        ).toEqual({
-          'X-External-User-ID': 'user1'
-        });
-      });
-    });
-  });
-
   describe('create', () => {
     const queryParams = {};
     let requestBuilder;

--- a/lib/repositories/__tests__/base-test.js
+++ b/lib/repositories/__tests__/base-test.js
@@ -78,6 +78,27 @@ describe('Repository', () => {
     });
   });
 
+  describe('sanitazeHeaders', () => {
+    describe('when headers are undefined', () => {
+      test('should return undefined', () => {
+        expect(repository.sanitazeHeaders()).toBeUndefined();
+      });
+    });
+
+    describe('when headers are not undefined', () => {
+      test('should return the allowed headers', () => {
+        expect(
+          repository.sanitazeHeaders({
+            'X-External-User-ID': 'user1',
+            'not-allowed-header': 'value-1'
+          })
+        ).toEqual({
+          'X-External-User-ID': 'user1'
+        });
+      });
+    });
+  });
+
   describe('create', () => {
     const queryParams = {};
     let requestBuilder;

--- a/lib/repositories/__tests__/base-test.js
+++ b/lib/repositories/__tests__/base-test.js
@@ -84,6 +84,7 @@ describe('Repository', () => {
     let requestBuilderMocked;
     let mockedService;
     let draft;
+    let externalHeaders;
     let res;
 
     beforeAll(() => {
@@ -95,10 +96,11 @@ describe('Repository', () => {
       requestBuilderMocked = jest.fn(() => mockedService);
       repository.requestBuilder = requestBuilderMocked;
       draft = { key: 'testKey' };
+      externalHeaders = { header1: 'value1' };
     });
 
     beforeEach(async () => {
-      res = await repository.create(draft);
+      res = await repository.create(draft, undefined, externalHeaders);
     });
 
     afterAll(() => {
@@ -113,6 +115,7 @@ describe('Repository', () => {
       expect(repository.connection.execute).toHaveBeenCalledWith({
         uri: repository.requestBuilder().parse(queryParams).build(),
         method: 'POST',
+        headers: { header1: 'value1' },
         body: JSON.stringify(draft)
       });
     });
@@ -250,6 +253,7 @@ describe('Repository', () => {
     let version;
     let actions;
     let queryParams;
+    let externalHeaders;
     let res;
 
     beforeAll(() => {
@@ -264,10 +268,17 @@ describe('Repository', () => {
       version = 1;
       actions = [{ action: 'setKey', value: 'testKey ' }];
       queryParams = { id, version };
+      externalHeaders = { header1: 'value1' };
     });
 
     beforeEach(async () => {
-      res = await repository.update(id, version, actions);
+      res = await repository.update(
+        id,
+        version,
+        actions,
+        undefined,
+        externalHeaders
+      );
     });
 
     afterAll(() => {
@@ -282,6 +293,7 @@ describe('Repository', () => {
       expect(repository.connection.execute).toHaveBeenCalledWith({
         uri: repository.requestBuilder().parse(queryParams).build(),
         method: 'POST',
+        headers: { header1: 'value1' },
         body: JSON.stringify({ version, actions })
       });
     });

--- a/lib/repositories/__tests__/custom-object-test.js
+++ b/lib/repositories/__tests__/custom-object-test.js
@@ -286,7 +286,7 @@ describe('Repository', () => {
     });
 
     it('should call create with params', () => {
-      expect(spy).toHaveBeenCalledWith(draft);
+      expect(spy).toHaveBeenCalledWith(draft, undefined, undefined);
     });
   });
 

--- a/lib/repositories/base.js
+++ b/lib/repositories/base.js
@@ -1,7 +1,5 @@
 const { createRequestBuilder } = require('@commercetools/api-request-builder');
 
-const ALLOWED_EXTERNAL_HEADERS = ['x-external-user-id'];
-
 /**
  * Base class with common repository operations
  */
@@ -46,20 +44,6 @@ class BaseRepository {
     return this.getRequestBuilder()[this.constructor.service];
   }
 
-  sanitazeHeaders(headers) {
-    if (!headers) {
-      return undefined;
-    }
-
-    const sanitazedHeaders = Object.keys(headers)
-      .filter(header =>
-        ALLOWED_EXTERNAL_HEADERS.includes(header.toLocaleLowerCase())
-      )
-      .map(header => [header, headers[header]]);
-
-    return Object.fromEntries(sanitazedHeaders);
-  }
-
   /**
    * Creates a new resource in commercetools
    * @param {Object} draft - resource draft
@@ -73,7 +57,7 @@ class BaseRepository {
         .parse({ ...(query && this.getParams(query)) })
         .build(),
       method: 'POST',
-      headers: this.sanitazeHeaders(externalHeaders),
+      headers: externalHeaders,
       body: JSON.stringify(draft)
     });
     return response.body;
@@ -123,7 +107,7 @@ class BaseRepository {
         .parse({ id, version, ...(query && this.getParams(query)) })
         .build(),
       method: 'POST',
-      headers: this.sanitazeHeaders(externalHeaders),
+      headers: externalHeaders,
       body: JSON.stringify({ version, actions })
     });
 
@@ -144,7 +128,7 @@ class BaseRepository {
         .parse({ id, version, ...(query && this.getParams(query)) })
         .build(),
       method: 'DELETE',
-      headers: this.sanitazeHeaders(externalHeaders)
+      headers: externalHeaders
     });
 
     return response.body;

--- a/lib/repositories/base.js
+++ b/lib/repositories/base.js
@@ -1,5 +1,7 @@
 const { createRequestBuilder } = require('@commercetools/api-request-builder');
 
+const ALLOWED_EXTERNAL_HEADERS = ['x-external-user-id'];
+
 /**
  * Base class with common repository operations
  */
@@ -44,18 +46,34 @@ class BaseRepository {
     return this.getRequestBuilder()[this.constructor.service];
   }
 
+  sanitazeHeaders(headers) {
+    if (!headers) {
+      return undefined;
+    }
+
+    const sanitazedHeaders = Object.keys(headers)
+      .filter(header =>
+        ALLOWED_EXTERNAL_HEADERS.includes(header.toLocaleLowerCase())
+      )
+      .map(header => [header, headers[header]]);
+
+    return Object.fromEntries(sanitazedHeaders);
+  }
+
   /**
    * Creates a new resource in commercetools
    * @param {Object} draft - resource draft
    * @param {Object} query - query parameters
+   * @param {Object} externalHeaders - headers to include in the request
    * @returns {Object} - the created resource
    */
-  async create(draft, query) {
+  async create(draft, query, externalHeaders) {
     const response = await this.connection.execute({
       uri: this.requestBuilder()
         .parse({ ...(query && this.getParams(query)) })
         .build(),
       method: 'POST',
+      headers: this.sanitazeHeaders(externalHeaders),
       body: JSON.stringify(draft)
     });
     return response.body;
@@ -96,14 +114,16 @@ class BaseRepository {
    * @param {number} version - resource version
    * @param {Object[]} actions - actions array
    * @param {Object} query - query parameters
+   * @param {Object} externalHeaders - headers to include in the request
    * @returns {Object} - the updated resource
    */
-  async update(id, version, actions, query) {
+  async update(id, version, actions, query, externalHeaders) {
     const response = await this.connection.execute({
       uri: this.requestBuilder()
         .parse({ id, version, ...(query && this.getParams(query)) })
         .build(),
       method: 'POST',
+      headers: this.sanitazeHeaders(externalHeaders),
       body: JSON.stringify({ version, actions })
     });
 
@@ -115,14 +135,16 @@ class BaseRepository {
    * @param {string} id - resource ID
    * @param {number} version - resource version
    * @param {Object} query - query parameters
+   * @param {Object} externalHeaders - headers to include in the request
    * @returns {Object} - the deleted resource
    */
-  async delete(id, version, query) {
+  async delete(id, version, query, externalHeaders) {
     const response = await this.connection.execute({
       uri: this.requestBuilder()
         .parse({ id, version, ...(query && this.getParams(query)) })
         .build(),
-      method: 'DELETE'
+      method: 'DELETE',
+      headers: this.sanitazeHeaders(externalHeaders)
     });
 
     return response.body;

--- a/lib/repositories/custom-object.js
+++ b/lib/repositories/custom-object.js
@@ -17,10 +17,12 @@ class CustomObject extends BaseRepository {
    * Wrapper to create function as custom objects has no update actions
    * {@link https://docs.commercetools.com/http-api-projects-custom-objects#create-or-update-a-customobject}
    * @param {Object} resource - updated resource
+   * @param {Object} query - query parameters
+   * @param {Object} externalHeaders - headers to include in the request
    * @returns {Object} - the updated resource
    */
-  async update(resource) {
-    return this.create(resource);
+  async update(resource, query, externalHeaders) {
+    return this.create(resource, query, externalHeaders);
   }
 
   /**

--- a/lib/repositories/customer.js
+++ b/lib/repositories/customer.js
@@ -59,13 +59,15 @@ class Customer extends BaseRepository {
    * @param {number} body.version - customer version
    * @param {string} body.currentPassword - customer current password
    * @param {string} body.newPassword - new password
+   * @param {Object} externalHeaders - headers to include in the request
    * @returns {Object} - The updated customer
    */
-  async passwordUpdate(body) {
+  async passwordUpdate(body, externalHeaders) {
     const { id, version, currentPassword, newPassword } = body;
     const response = await this.connection.execute({
       uri: this.getRequestBuilder().customersPassword.parse({}).build(),
       method: 'POST',
+      headers: externalHeaders,
       body: JSON.stringify({ id, version, currentPassword, newPassword })
     });
 


### PR DESCRIPTION
Allow send external headers to the ct API. In this case we are going to include only the x-external-user-id
https://docs.commercetools.com/api/client-logging#external-user-ids